### PR TITLE
fix(exports): remove exports and update target

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,10 +4,6 @@
   "description": "A tree data structure",
   "main": "dist/MAryTree.js",
   "types": "dist/MAryTree.d.ts",
-  "exports": {
-    ".": "./dist/MAryTree.js",
-    "./positioning-algorithms/*": "./dist/positioning-algorithms/*.js"
-  },
   "repository": "git@github.com:jsakas/m-ary-tree.git",
   "author": "Jon Sakas <jon.sakas@gmail.com>",
   "license": "MIT",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,13 +5,9 @@
     "downlevelIteration": true,
     "declaration": true,
     "outDir": "dist",
-    "target": "ES5",
-    "sourceMap": true,
+    "target": "ESNext",
+    "sourceMap": true
   },
-  "exclude": [
-    "src/**/*.test.ts"
-  ],
-  "include": [
-    "src/**/*.ts"
-  ]
+  "exclude": ["src/**/*.test.ts"],
+  "include": ["src/**/*.ts"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,7 @@
     "downlevelIteration": true,
     "declaration": true,
     "outDir": "dist",
-    "target": "ESNext",
+    "target": "ES2015",
     "sourceMap": true
   },
   "exclude": ["src/**/*.test.ts"],


### PR DESCRIPTION
Removed exports that were causing issues with imports while running Vite and changed target to ESNext. @jsakas, do you think ESNext is a reasonable target for the lib? 